### PR TITLE
cluster: update BuildImage error msg

### DIFF
--- a/cluster/image.go
+++ b/cluster/image.go
@@ -278,7 +278,7 @@ func (c *Cluster) BuildImage(buildOptions docker.BuildImageOptions) error {
 		return err
 	}
 	if len(nodes) < 1 {
-		return errors.New("There is no docker node. Please list one in tsuru.conf or add one with `tsuru-admin docker-node-add`.")
+		return errors.New("There is no docker node. Please list one in tsuru.conf or add one with `tsuru node-add`.")
 	}
 	nodeAddress := nodes[0].Address
 	node, err := c.getNodeByAddr(nodeAddress)


### PR DESCRIPTION
This PR updates BuildImage error msg replacing tsuru-admin for tsuru and docker-node-add to node-add.