### PR TITLE
cluster: always try pulling image, but ignore error if no registry

### DIFF
--- a/cluster/container.go
+++ b/cluster/container.go
@@ -113,9 +113,9 @@ func (c *Cluster) CreateContainerPullOptsSchedulerOpts(opts docker.CreateContain
 
 func (c *Cluster) createContainerInNode(opts docker.CreateContainerOptions, pullOpts docker.PullImageOptions, pullAuth docker.AuthConfiguration, nodeAddress string) (*docker.Container, error) {
 	registryServer, _ := parseImageRegistry(opts.Config.Image)
-	if registryServer != "" {
-		err := c.PullImage(pullOpts, pullAuth, nodeAddress)
-		if err != nil {
+	err := c.PullImage(pullOpts, pullAuth, nodeAddress)
+	if err != nil {
+		if registryServer != "" {
 			return nil, err
 		}
 	}

--- a/cluster/image.go
+++ b/cluster/image.go
@@ -85,6 +85,9 @@ func (c *Cluster) removeImage(name string, ignoreLast bool) error {
 func parseImageRegistry(imageId string) (string, string) {
 	parts := strings.SplitN(imageId, "/", 3)
 	if len(parts) < 3 {
+		if len(parts) == 2 && (strings.ContainsAny(parts[0], ":.") || parts[0] == "localhost") {
+			return parts[0], parts[1]
+		}
 		return "", strings.Join(parts, "/")
 	}
 	return parts[0], strings.Join(parts[1:], "/")

--- a/cluster/image_test.go
+++ b/cluster/image_test.go
@@ -840,3 +840,29 @@ func TestImageHistory(t *testing.T) {
 		t.Fatalf("Expected image id to be 'id1', got: %s", historyData[0].ID)
 	}
 }
+
+func TestParseImageRegistry(t *testing.T) {
+	tests := []struct {
+		image    string
+		registry string
+		name     string
+	}{
+		{"tsuru/python", "", "tsuru/python"},
+		{"img", "", "img"},
+		{"localhost/tsuru/python", "localhost", "tsuru/python"},
+		{"localhost/img", "localhost", "img"},
+		{"othername:5000/img", "othername:5000", "img"},
+		{"my.long.host/img", "my.long.host", "img"},
+		{"my.long.host:5000/img", "my.long.host:5000", "img"},
+		{"my.long.host:5000/img/img", "my.long.host:5000", "img/img"},
+	}
+	for i, tt := range tests {
+		reg, name := parseImageRegistry(tt.image)
+		if reg != tt.registry {
+			t.Fatalf("[test %d] expected registry %q, got: %q", i, tt.registry, reg)
+		}
+		if name != tt.name {
+			t.Fatalf("[test %d] expected name %q, got: %q", i, tt.name, name)
+		}
+	}
+}


### PR DESCRIPTION
Also fix image registry parsing to match what docker does.