### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cluster/image.go
+++ b/cluster/image.go
@@ -150,7 +150,7 @@ func (c *Cluster) PushImage(opts docker.PushImageOptions, auth docker.AuthConfig
 	return wrapError(node, node.PushImage(opts, auth))
 }
 
-// InspectContainer inspects an image based on its repo name
+// InspectImage inspects an image based on its repo name
 func (c *Cluster) InspectImage(repo string) (*docker.Image, error) {
 	img, err := c.storage().RetrieveImage(repo)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?