### PR TITLE
Maintaining consistency in receiver type

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -57,7 +57,7 @@ func (a NodeList) Len() int           { return len(a) }
 func (a NodeList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a NodeList) Less(i, j int) bool { return a[i].Address < a[j].Address }
 
-func (n Node) MarshalJSON() ([]byte, error) {
+func (n *Node) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Address":  n.Address,
 		"Metadata": n.Metadata,


### PR DESCRIPTION
If some of the methods of the type must have pointer receivers, the rest should too, so the method set is consistent regardless of how the type is used.

https://golang.org/doc/faq#methods_on_values_or_pointers